### PR TITLE
fix: server name nginx/nginx.conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,7 +6,7 @@ http {
     server {
     
         listen 8000;
-        server_name http://54.164.65.171;
+        server_name _;
 
         location / {
             proxy_pass http://web:3000;  # Forward requests to FastAPI


### PR DESCRIPTION
## Description
- Remove AWS public IP to allow request from anywhere to the server